### PR TITLE
make fullscreen button a toggle

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -138,7 +138,11 @@ function createFullscreenButton (title) {
 
 function handleFullscreen () {
   const tabsWithPaddingWrapper = document.querySelector(tabsWithPaddingSelector)
-  tabsWithPaddingWrapper.requestFullscreen()
+  if (document.fullscreenElement) {
+    document.exitFullscreen()
+  } else {
+    tabsWithPaddingWrapper.requestFullscreen()
+  }
 }
 
 function setupControls () {


### PR DESCRIPTION
Makes the fullscreen button a toggle so that it can be used to exit fullscreen if you're already in fullscreen mode. 